### PR TITLE
fix: resolve noUnusedLocals (and semver peerDep) errors in consumer

### DIFF
--- a/defs.d.ts
+++ b/defs.d.ts
@@ -1,0 +1,1 @@
+declare module 'electron';

--- a/fetch.js
+++ b/fetch.js
@@ -36,7 +36,7 @@ function waitBeforeRetry(tryNum) {
  *
  * @param {string} address - requested URL (must start with `https://`)
  * @param {string?} [contentType] - expected content-type or undefined/null to not check it
- * @returns {Promise<http.IncomingMessage>}
+ * @returns {Promise<https.IncomingMessage>}
  */
 function get(address, contentType, redirs = 0, tries = 0) {
     return new Promise((fulfill, reject) => {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 // @ts-check
-const fs = require('fs');
 const path = require('path');
 const Updater = require('./updater');
 const { app } = require('electron');

--- a/install-linux.js
+++ b/install-linux.js
@@ -31,7 +31,7 @@ SOFTWARE.
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { execFile, exec, spawn } = require('child_process');
+const { execFile, exec } = require('child_process');
 const { app } = require('electron');
 
 async function install(updatePath, restart) {

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
   },
   "homepage": "https://github.com/PeerioTechnologies/peerio-updater#readme",
   "peerDependencies": {
-    "electron": "1.x.x"
+    "electron": "1.x.x || 2.x.x"
   },
   "devDependencies": {
     "@types/node": "8.0.0",
     "chai": "4.0.2",
-    "mocha": "3.4.2"
+    "mocha": "^5.2.0"
   },
   "dependencies": {
     "mkdirp": "0.5.1",


### PR DESCRIPTION
Attempting to turn `noUnusedLocals` on in `tsconfig.json` in peerio-desktop, `tsc` unfortunately gets a little zealous about which files it's checking:
```
 > peerio-2@3.2.1 test:ts /home/six/Code/desktop
> tsc --noEmit

app/node_modules/@peerio/updater/index.js(2,7): error TS6133: 'fs' is declared but its value is never read.
```
No variant of include/exclude paths configuration seems to prevent it from doing this -- seems like it might be a compiler bug or regression encountered when a node module uses `@ts-check`. I'll file an issue for that shortly, but in the meantime I thought I'd fix the problem at the source as well :)

This PR also adjusts the `peerDependency` for `electron` to suppress warnings on peerio-desktop, upgrades `mocha` to address a critical vulnerability `npm install` was screaming about, and suppresses/fixes one or two other minor typings errors/warnings.